### PR TITLE
testing endor labs agenthq comment pr capability - adding com.fasterxml.jackson.core:jackson-databind@2.9.10 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>commons-text</artifactId>
             <version>1.9</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.10</version>
+        </dependency>
        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
this PR is used to test endor labs agenthq comment pr capability